### PR TITLE
Fix Sphinx config path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,11 +11,11 @@ else:
 
 sys.path.append(os.path.abspath(os.pardir))
 
+import lumache
+
 
 with open("../pyproject.toml", "rb") as f:
-    project_data = tomllib.load(f).get("project")
-    if project_data is None:
-        raise KeyError("project data is not found")
+    project_data = tomllib.load(f).get("project") or {}
 
 
 # -- General configuration ----------------------------------------------------
@@ -25,23 +25,26 @@ gettext_compact = False
 gettext_uuid = True
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
     "sphinxext.opengraph",
 ]
 source_suffix = ".rst"
 master_doc = "index"
-project = project_data.get("name").upper()
+project = project_data.get("name", "LUMACHE").upper()
 year = datetime.datetime.fromtimestamp(
     int(os.environ.get("SOURCE_DATE_EPOCH", time.time())), datetime.timezone.utc
 ).year
 project_copyright = f"2010–{year}"  # noqa: RUF001
 exclude_patterns = ["_build"]
-release = project_data.get("version")
+release = project_data.get("version") or lumache.__version__
 version = ".".join(release.split(".")[:1])
-last_stable = project_data.get("version")
+last_stable = release
+requires_python = project_data.get("requires-python") or ""
+min_python = requires_python.split(",")[0] if requires_python else "N/A"
 rst_prolog = f"""
 .. |last_stable| replace:: :pelican-doc:`{last_stable}`
-.. |min_python| replace:: {project_data.get("requires-python").split(",")[0]}
+.. |min_python| replace:: {min_python}
 """
 
 extlinks = {"pelican-doc": ("https://docs.getpelican.com/en/latest/%s.html", "%s")}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,6 +2,12 @@
 
 # -- Project information
 
+import os
+import sys
+
+# Add project root to sys.path so Sphinx can find ``lumache``
+sys.path.insert(0, os.path.abspath("../.."))
+
 project = 'Lumache'
 copyright = '2021, Graziella'
 author = 'Graziella'


### PR DESCRIPTION
## Summary
- ensure Sphinx can locate the `lumache` module
- handle missing fields when loading from `pyproject.toml`
- enable `autosummary` in Sphinx configuration

## Testing
- `python -m sphinx -b html docs/source _build/html`


------
https://chatgpt.com/codex/tasks/task_e_68789ee5737c8329929ffa174717a6a9